### PR TITLE
Fix uninitialized warning

### DIFF
--- a/lib/Log/Log4perl/Layout/JSON.pm
+++ b/lib/Log/Log4perl/Layout/JSON.pm
@@ -255,7 +255,7 @@ sub render {
                     $len = length $encoded;
                 }
                 else {
-                    $len = length $v;
+                    $len = defined $v ? length $v : 0;
                 }
                 next if $len <= $max_json_length/2;
 


### PR DESCRIPTION
When we truncate JSON we set complex fields (ref $v returns something) to undef. It cause a warning when we get length of $v